### PR TITLE
Allow Blanks after doze

### DIFF
--- a/app/src/main/assets/overlays/android/res/values/bools.xml
+++ b/app/src/main/assets/overlays/android/res/values/bools.xml
@@ -6,7 +6,7 @@
     <bool name="config_dozeAfterScreenOff">false</bool>
     <bool name="config_dozePulsePickup">true</bool>
     <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
-    <bool name="config_displayBlanksAfterDoze">false</bool>
+    <bool name="config_displayBlanksAfterDoze">true</bool>
     <bool name="config_displayBrightnessBucketsInDoze">true</bool>
     <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
     <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>


### PR DESCRIPTION
This will allow the screen to blank and transition from doze to active. Should help with the double tap to wake and power button to wake problems.